### PR TITLE
Condense SKILL.md description from 925 to 369 chars

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hallmark
-description: "Anti-AI-slop design skill — landing pages, audits, redesigns, and DNA-extraction from URLs or screenshots. Four verbs: `audit <target>`, `redesign <target>`, `study <URL | screenshot>`, or default (build new). Fires when ANY: (1) user names a verb; (2) user says a UI feels AI-generated, looks templated, or asks to make it less AI-generated; (3) user attaches a screenshot or URL of a design they admire (`study`); (4) user invokes Hallmark by name; (5) user asks for a greenfield full-page or full-site build with no existing styled UI. Does NOT fire on: (i) component-scope requests (button, navbar, form, modal); (ii) iteration on an existing styled page (tweaks, copy edits, adding a section); (iii) any request inside a codebase with an existing design system, unless Hallmark is invoked by name. Decisive signal: is there existing styled UI the user wants preserved? If yes, stay silent. If no (true greenfield), fire."
+description: "Anti-AI-slop design skill for greenfield pages, audits, redesigns, and DNA-extraction from URLs or screenshots. Use when the user asks to build a new landing page or full-page UI, says a design looks AI-generated or templated, invokes Hallmark by name, or uses audit/redesign/study. Does not activate for single-component requests or iteration on existing styled pages."
 version: 1.0.0
 ---
 


### PR DESCRIPTION
## Problem

The `description` frontmatter field was 925 characters and encoded the full routing logic — numbered trigger lists, decisive-signal heuristic, exhaustive negative conditions. That detail already lives in the SKILL.md body (lines 19–63). The description's job is to help the agent platform decide *when to load* the skill, not to execute the routing.

At 925 chars it was also approaching the 1,024-char hard limit for skill descriptions, leaving almost no room for future additions.

## Fix

Condensed to **369 chars** (~60% reduction) following the pattern established by Anthropic's `frontend-design` skill (~370 chars): `[What it does] + [Use when…] + [Scope boundary]`.

### Before (925 chars)
```
Anti-AI-slop design skill — landing pages, audits, redesigns, and DNA-extraction from URLs or screenshots. Four verbs: `audit <target>`, `redesign <target>`, `study <URL | screenshot>`, or default (build new). Fires when ANY: (1) user names a verb; (2) user says a UI feels AI-generated, looks templated, or asks to make it less AI-generated; (3) user attaches a screenshot or URL of a design they admire (`study`); (4) user invokes Hallmark by name; (5) user asks for a greenfield full-page or full-site build with no existing styled UI. Does NOT fire on: (i) component-scope requests (button, navbar, form, modal); (ii) iteration on an existing styled page (tweaks, copy edits, adding a section); (iii) any request inside a codebase with an existing design system, unless Hallmark is invoked by name. Decisive signal: is there existing styled UI the user wants preserved? If yes, stay silent. If no (true greenfield), fire.
```

### After (369 chars)
```
Anti-AI-slop design skill for greenfield pages, audits, redesigns, and DNA-extraction from URLs or screenshots. Use when the user asks to build a new landing page or full-page UI, says a design looks AI-generated or templated, invokes Hallmark by name, or uses audit/redesign/study. Does not activate for single-component requests or iteration on existing styled pages.
```

## What's preserved

Every critical trigger keyword: `audit`, `redesign`, `study`, `greenfield`, `AI-generated`, `templated`, `landing page`, `DNA-extraction`, `Hallmark by name`. Plus the negative scope boundary (single-component requests, iteration on existing styled pages).

## What's dropped

- Numbered list formatting (`(1)…(2)…(3)…`)
- The decisive-signal heuristic ("is there existing styled UI?") — already in the body at lines 52–63
- Redundant phrasing (`build new` → covered by `greenfield`)
- Verb syntax details (``audit <target>``) — the body has the full invocation table

## Verification

```
$ python3 -c "import yaml; print(yaml.safe_load(open('SKILL.md').read().split('---')[1]))"
# {'name': 'hallmark', 'description': '...369 chars...', 'version': '1.0.0'}
```

One-line change, no content altered in the skill body.