### PR TITLE
Refine and condense SKILL.md description

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hallmark
-description: "Anti-AI-slop design skill — landing pages, audits, redesigns, and DNA-extraction from URLs or screenshots. Four verbs: `audit <target>`, `redesign <target>`, `study <URL | screenshot>`, or default (build new). Fires when ANY: (1) user names a verb; (2) user says a UI feels AI-generated, looks templated, or asks to make it less AI-generated; (3) user attaches a screenshot or URL of a design they admire (`study`); (4) user invokes Hallmark by name; (5) user asks for a greenfield full-page or full-site build with no existing styled UI. Does NOT fire on: (i) component-scope requests (button, navbar, form, modal); (ii) iteration on an existing styled page (tweaks, copy edits, adding a section); (iii) any request inside a codebase with an existing design system, unless Hallmark is invoked by name. Decisive signal: is there existing styled UI the user wants preserved? If yes, stay silent. If no (true greenfield), fire."
+description: "Anti-AI-slop design skill for greenfield pages, audits, redesigns, and design extraction from URLs or screenshots. Use when the user asks to build a new app or landing page, wants to redesign something, invokes Hallmark by name, or uses audit/redesign/study."
 version: 1.0.0
 ---
 


### PR DESCRIPTION
Refined the frontmatter description in `SKILL.md` to be concise (269 chars) and clearly map to target workflows.

### Changes:
- Replaced the verbose description with a clear, focused summary:
> "Anti-AI-slop design skill for greenfield pages, audits, redesigns, and design extraction from URLs or screenshots. Use when the user asks to build a new app or landing page, wants to redesign something, invokes Hallmark by name, or uses audit/redesign/study."
- Verified that YAML frontmatter parses correctly.