### PR TITLE
docs: fix Cursor skill install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ npx skills add nutlope/hallmark
 Re-run any time to update. Or copy [`SKILL.md`](skills/hallmark/SKILL.md) + [`references/`](skills/hallmark/references/) into:
 
 - **Claude Code**: `~/.claude/skills/hallmark/`
-- **Cursor**: `.cursor/rules/hallmark.mdc` (body of `SKILL.md`, no frontmatter)
+- **Cursor**: `.agents/skills/hallmark/` in your project
 - **Codex**: `~/.codex/skills/hallmark/` (personal) or `.codex/skills/hallmark/` (project-scoped)
 
 The rule-set lives in [`SKILL.md`](skills/hallmark/SKILL.md) and [`references/`](skills/hallmark/references/). Worked examples in [`docs/recipes.md`](docs/recipes.md) and [`docs/study-examples.md`](docs/study-examples.md).


### PR DESCRIPTION
## Summary
- update the manual Cursor install path to use a skill directory instead of a `.cursor/rules` file
- keep `SKILL.md` and `references/` together so the referenced Hallmark rules remain available to the assistant

Closes #22.

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json valid')"`
- `rg -n "Cursor|\\.cursor/rules|\\.agents/skills" README.md`