### PR TITLE
Fix stale nav archetype range in SKILL.md and macrostructures.md

### DIFF
--- a/skills/hallmark/SKILL.md
+++ b/skills/hallmark/SKILL.md
@@ -82,7 +82,7 @@ If two signals fire, route component. If only the page flow fires (multi-section
 ### What Component-scope skips
 
 - **Step 2 · Macrostructure pick.** Components don't have macrostructures. State this explicitly: *"Component-scope: skipping macrostructure."*
-- **Nav and footer archetype picks.** N1–N9 and Ft1–Ft8 are page-scope only. A component is one element; it has no nav, no footer. Skip both.
+- **Nav and footer archetype picks.** N1a–N13 and Ft1–Ft8 are page-scope only. A component is one element; it has no nav, no footer. Skip both.
 - **Hero polish patterns (HP1–HP4).** Page-scope only. A button or card has no hero.
 - **Step 4 · Enrichment.** No hero illustration, no demo video, no abstract background. The component IS the artifact.
 - **Step 5 · Multi-section preview.** Replaced by the 8-state demo wrapper (below).

--- a/skills/hallmark/references/macrostructures.md
+++ b/skills/hallmark/references/macrostructures.md
@@ -18,7 +18,7 @@ A hero may carry one enrichment archetype (E1–E8) AND one polish pattern (HP1�
 
 ## Nav and footer voice
 
-Each macrostructure also implies a **nav archetype** (N1–N9) and a **footer archetype** (Ft1–Ft8). The defaults sit in the routing tables in [`component-cookbook.md`](component-cookbook.md) § Navigation and § Footers. Don't ship a hero macrostructure without picking nav + footer alongside — they are part of the page shape, not optional chrome.
+Each macrostructure also implies a **nav archetype** (N1a–N13) and a **footer archetype** (Ft1–Ft8). The defaults sit in the routing tables in [`component-cookbook.md`](component-cookbook.md) § Navigation and § Footers. Don't ship a hero macrostructure without picking nav + footer alongside — they are part of the page shape, not optional chrome.
 
 ---
 


### PR DESCRIPTION
## Summary

- `SKILL.md:85` and `references/macrostructures.md:21` both state the nav archetype range as `N1–N9`, but the catalog has grown to 14 archetypes, `N1a–N13` (confirmed by `SKILL.md:290`, `references/component-cookbook.md`, and the 14 files under `references/components/n*.md`).
- The stale range is self-contradicted within `SKILL.md` itself — line 290 already correctly says "fourteen archetypes" and lists all of `N1a` through `N13`.
- Left as-is, the two stale lines undersell 5 of the 14 valid nav archetypes to anything reading them.

## Change

Two one-line edits, updating `N1–N9` to `N1a–N13` in both files. No other content touched.

## Test plan

- [x] Verified no other `N1–N9` / `N1-N9` references remain anywhere in the repo (`grep -r`)
- [x] Confirmed `N1a–N13` matches the exact range and count already stated at `SKILL.md:290` and the 14 files under `references/components/n*.md`