### PR TITLE
docs: fix recipe and study links

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,6 +1,6 @@
 # Recipes — copy-paste prompts that ship Hallmark output
 
-Eight worked briefs you can paste into Claude Code, Cursor, or Codex with the Hallmark skill installed. Each shows the prompt verbatim, the audience/use/tone the skill inferred, the macrostructure + theme + enrichment it picked, and a one-paragraph excerpt of the output. Live page links are included where the test exists in [`site/_tests/`](../../site/_tests/).
+Eight worked briefs you can paste into Claude Code, Cursor, or Codex with the Hallmark skill installed. Each shows the prompt verbatim, the audience/use/tone the skill inferred, the macrostructure + theme + enrichment it picked, and a one-paragraph excerpt of the output. Live page links are included where the test exists in [`site/_tests/`](../site/_tests/).
 
 The first recipe is the **canonical try-it prompt** — paste it into a fresh project to verify the skill is installed and discover the flow before reading anything else.
 
@@ -38,7 +38,7 @@ The first recipe is the **canonical try-it prompt** — paste it into a fresh pr
 
 > *"Dear listener, Tide is a podcast about how small studios actually work. The bookings, the unsent invoices, the day a senior designer leaves and you sit in the office not knowing what to say to the four people who stayed."* The hero is the salutation. Below: three paragraphs of host-voice, a sign-off, then a single row of "listen where you listen" links — Apple, Spotify, Pocket Casts, Overcast, RSS. No mockups. No demo. The voice carries the brand.
 
-**Live:** [`_tests/01-tide-podcast/`](../../site/_tests/01-tide-podcast/index.html)
+**Live:** [`_tests/01-tide-podcast/`](../site/_tests/01-tide-podcast/index.html)
 
 ---
 
@@ -56,7 +56,7 @@ The first recipe is the **canonical try-it prompt** — paste it into a fresh pr
 
 > *"$ streampipe — a small, fast, single-binary CLI for parsing log and event streams from stdin."* Then a paragraph of prose explaining what it does, an inline `<pre>` showing `tail -f access.log | streampipe parse --format nginx --filter 'status >= 500' --out json` with three sample JSON output lines, then a second paragraph (Rust, 1.2 MB binary, no daemon, no buffer). Below: install section (three snippets — brew · cargo · curl), three numbered notes on how it works, a six-row flag table. Pure CSS, no scripts.
 
-**Live:** [`_tests/02-streampipe-cli/`](../../site/_tests/02-streampipe-cli/index.html)
+**Live:** [`_tests/02-streampipe-cli/`](../site/_tests/02-streampipe-cli/index.html)
 
 ---
 
@@ -74,7 +74,7 @@ The first recipe is the **canonical try-it prompt** — paste it into a fresh pr
 
 > Plate-banner masthead: *"Maple Street Bread · Lisbon · est. 2026 · n.º 47 · sourdough by hand."* Then a centred section: *"Today's bake — Saturday, 6:14 a.m., eight breads, gone by noon."* Below: a 2-column catalogue grid of eight breads (Country sourdough · Baguette tradition · Focaccia rosemary · Boule miche · Rye dark · Brioche feuilletée · Walnut levain · Bola d'óleo). Each row carries a 96-px bread silhouette, the name in IM Fell, a one-line description, and a price (or "sold out"). Visit and hours in a centred almanac panel at the bottom. No CTA — the brief is "see what's available + visit."
 
-**Live:** [`_tests/03-maple-bakery/`](../../site/_tests/03-maple-bakery/index.html)
+**Live:** [`_tests/03-maple-bakery/`](../site/_tests/03-maple-bakery/index.html)
 
 ---
 
@@ -92,7 +92,7 @@ The first recipe is the **canonical try-it prompt** — paste it into a fresh pr
 
 > A single twenty-word pull-quote: *"We make products that don't outlive their use"* — with a yellow strike-through behind "outlive." Attribution beneath: *"— The studio · the position we open with · this is the page."* Below the bleed-yellow rule, four numbered principles (Fewer things, made well · Material is the brief · Repair before replace · Slow is the deliverable), each with one paragraph of body copy. Final § Working rules — five terse operational statements (the shop runs on a four-day week · we answer the email ourselves · etc.). No CTA, no testimonials, no roadmap.
 
-**Live:** [`_tests/04-meridian-manifesto/`](../../site/_tests/04-meridian-manifesto/index.html)
+**Live:** [`_tests/04-meridian-manifesto/`](../site/_tests/04-meridian-manifesto/index.html)
 
 ---
 
@@ -110,7 +110,7 @@ The first recipe is the **canonical try-it prompt** — paste it into a fresh pr
 
 > *"Tracejam · v0.4 · For SREs &amp; platform engineers. Distributed tracing that explains itself."* Hero left-aligned with two CTAs (Try it free / Talk to sales). On the right, a sample trace card with five spans — auth.verify, pricing.quote (red, regressed), rates.fx (orange, warning), ledger.write — bars rendered as flex children. Below: a sticky-walkthrough section with three steps (open · find · read), each with a one-paragraph body and a small `$ tracejam ...` command. The right column carries a pinned trace panel with a "REGRESSED" chip and a "WHY" explainer in plain text. Eight integrations strip, three-tier pricing, single-line colophon.
 
-**Live:** [`_tests/05-tracejam-saas/`](../../site/_tests/05-tracejam-saas/index.html)
+**Live:** [`_tests/05-tracejam-saas/`](../site/_tests/05-tracejam-saas/index.html)
 
 ---
 
@@ -128,7 +128,7 @@ The first recipe is the **canonical try-it prompt** — paste it into a fresh pr
 
 > Sticky left sidebar with a numbered TOC: *00 Index · 01 Now · 02 Years · 03 Writing · 04 Reach.* Each section in the right column starts with its own num + label and a clamp-set H2. *"00 · Index"* opens with *"A small, scannable index of who I am and what I do."* — followed by a two-paragraph bio. *"01 · Now"* covers consulting two engagements at a time on payment systems and monolith-to-services migrations. *"02 · Years"* is a tabular work history (Stripe → Monzo → Knot → independent). *"03 · Writing"* lists five linked pieces with date columns. *"04 · Reach"* is a four-cell contact grid (email · GitHub · LinkedIn · Mastodon).
 
-**Live:** [`_tests/06-anya-portfolio/`](../../site/_tests/06-anya-portfolio/index.html)
+**Live:** [`_tests/06-anya-portfolio/`](../site/_tests/06-anya-portfolio/index.html)
 
 ---
 
@@ -146,7 +146,7 @@ The first recipe is the **canonical try-it prompt** — paste it into a fresh pr
 
 > Newspaper-banner masthead with the wordmark centred. Hero left-bias: *"Compliance, ground out in **days**, not in months."* — the word "days" set in red italic. Right: a pull-quote panel with a CTO testimonial. Below: a 6-tile bento — (1) the "847." anchor stat with a one-line caption, (2) eight customer wordmarks in a 4×2 logo grid, (3) three-tier pricing snippet (Starter $299 · Team $899 popular · Scale custom), (4) a second testimonial pull-quote, (5) a six-row "what's automated" feat-list, (6) a six-question FAQ teaser. Final CTA strip: *"Start the trial. Cancel before the first invoice if it's not ready."* Single-line colophon.
 
-**Live:** [`_tests/07-foundry-compliance/`](../../site/_tests/07-foundry-compliance/index.html)
+**Live:** [`_tests/07-foundry-compliance/`](../site/_tests/07-foundry-compliance/index.html)
 
 ---
 
@@ -164,7 +164,7 @@ The first recipe is the **canonical try-it prompt** — paste it into a fresh pr
 
 > Centred eyebrow: *"Built for educators · not LMS sales teams."* Hero stat at 22 rem: **"30 — 500"** (with the dash in warm-amber). Headline: *"Live courses, the size your roster actually is."* Sub: *"Cohort runs courses with thirty to five hundred students at once — the size of a real classroom, the size of a real lecture, and a few sizes between. With a date, a roster, and a room."* Below: three supporting stats (186 cohorts run · 93 % finish-rate · 4.7/5 operator NPS). Two operator testimonials side-by-side. Two-tier pricing (First cohort free · Operator $199/mo). Single CTA strip and colophon. No marquee, no card-stack — the brief carried by the typography.
 
-**Live:** [`_tests/08-cohort-courses/`](../../site/_tests/08-cohort-courses/index.html)
+**Live:** [`_tests/08-cohort-courses/`](../site/_tests/08-cohort-courses/index.html)
 
 ---
 
@@ -181,6 +181,6 @@ When generating something new, look for the closest match in this file and **not
 
 ## What the recipes are *not*
 
-- Not templates. Hallmark's whole point is structural variety — duplicating a recipe verbatim is the **Specimen-fall-through** anti-pattern (gate 23 in [`SKILL.md`](../SKILL.md)).
-- Not fixed picks. Two consecutive runs of recipe 00 (Coffeebox) on the same project should produce *different* macrostructures or themes — the [`.hallmark/log.json`](../SKILL.md) project memory enforces this.
+- Not templates. Hallmark's whole point is structural variety — duplicating a recipe verbatim is the **Specimen-fall-through** anti-pattern (gate 23 in [`SKILL.md`](../skills/hallmark/SKILL.md)).
+- Not fixed picks. Two consecutive runs of recipe 00 (Coffeebox) on the same project should produce *different* macrostructures or themes — the [`.hallmark/log.json`](../skills/hallmark/SKILL.md) project memory enforces this.
 - Not exhaustive. The 21 macrostructures × 16 themes × 8 enrichment archetypes = 2,688 distinct fingerprints. The 9 recipes here are a starter set; the next 50 are yours to discover.

--- a/docs/study-examples.md
+++ b/docs/study-examples.md
@@ -173,4 +173,4 @@ Output: the user's actual name in italic-Fraunces top-left, their demo (e.g. an 
 3. **Refuses the obvious bad sources.** Paid-template-marketplace listings; copy-protected portfolios without permission.
 4. **Always disclosures the substitutions.** When the screenshot's font is paid (Tiempos / Söhne / Druk) and the user hasn't confirmed a licence, the skill names a free understudy (Fraunces / Inter Tight / Bricolage Grotesque) and *says it's substituting*.
 
-These three examples cover the most common categories of `study` request: an editorial portfolio, a type-specimen statement page, and a small personal site. The protocol is the same for every screenshot — refuse-or-proceed, diagnose, confirm, build. See [`study.md`](study.md) for the full protocol.
+These three examples cover the most common categories of `study` request: an editorial portfolio, a type-specimen statement page, and a small personal site. The protocol is the same for every screenshot — refuse-or-proceed, diagnose, confirm, build. See [`study.md`](../skills/hallmark/references/study.md) for the full protocol.


### PR DESCRIPTION
## Summary

Fix repository-relative links in the Hallmark recipes and study examples.

## Root cause

The documentation files live under `docs/`, but their links still used paths
from their former location. As a result, the recipes index, eight live examples,
the skill references, and the study protocol link resolved outside the repository
or to a nonexistent file.

## Validation

- Ran a relative-link check across `docs/`; all local Markdown targets resolve.
- Ran `git diff --check`.
