### PR TITLE
fix: fall back to a real theme when data-theme is unknown

### DIFF
--- a/site/js/main.js
+++ b/site/js/main.js
@@ -771,9 +771,13 @@ const queried = (() => {
 const stored = (() => {
   try { return localStorage.getItem(STORAGE_KEY); } catch (e) { return null; }
 })();
+// The pre-paint script in index.html sets data-theme from ?theme= /
+// localStorage without checking the registry, so validate it here too —
+// otherwise an unknown value survives and gets written back to storage.
 const initial = THEMES[queried] ? queried
   : THEMES[stored] ? stored
-    : (root.dataset.theme || "hum");
+    : THEMES[root.dataset.theme] ? root.dataset.theme
+      : "hum";
 
 // First paint — populate slots without a transition (no flash).
 // Run swapArchetypes BEFORE setPressed so the footer template is materialised


### PR DESCRIPTION
Fixes #38

The theme resolver's last fallback read `root.dataset.theme` back, which the pre-paint script had already set from an unvalidated `?theme=` / localStorage value. The bad value survived and was persisted, leaving the picker desynced on every later visit.

Validates the attribute against `THEMES` before using it, so an unknown value lands on `hum` and self-heals stale storage.

Verified locally:
- `/?theme=totally-not-a-theme` → `data-theme="hum"`, storage `"hum"`, Hum dot pressed
- stale `localStorage` entry → corrected on next load
- `/?theme=carnival` → unchanged (Carnival, 18 / 20, marquee hero)