### PR TITLE
fix: hold the demo videos on frame one under reduced motion

### DIFF
--- a/site/js/main.js
+++ b/site/js/main.js
@@ -38,6 +38,19 @@ document.querySelectorAll(".reveal").forEach((el) => el.classList.add("is-in"));
   // On touch devices, the autoplay attribute already runs the loop.
 }
 
+/* — Reduced motion — hold the demo loops on their first frame ————
+   The Build and Redesign demos are `<video autoplay loop>` with no
+   poster, so they loop indefinitely no matter what the visitor asked
+   for. Park them on frame one instead — same static-preview treatment
+   the hover-play videos above get on desktop. */
+if (reduced) {
+  document.querySelectorAll("video[autoplay]").forEach((video) => {
+    video.removeAttribute("autoplay");
+    video.loop = false;
+    try { video.pause(); video.currentTime = 0; } catch (_) {}
+  });
+}
+
 /* — Theme registry ————————————————————————————————————— */
 const THEMES = {
   hum: "Hum",


### PR DESCRIPTION
Fixes #43

The two demo loops are `<video autoplay loop>` with no `poster`, and nothing paused them when `prefers-reduced-motion: reduce` was set — the existing reduced-motion video rule targets `.ex-card__thumb` (no such element ships) and sets `animation-play-state`, which does not stop media playback.

Parks them on the first frame instead, reusing the static-preview treatment the hover-play videos above already get, so the block sits next to the code it mirrors.

Verified locally: the selector matches both videos, and after the block runs each one reports `autoplay` removed, `loop: false`, `paused: true`, `currentTime: 0`. No console errors, and the default (motion-on) path is unchanged.