### PR TITLE
docs: fix recipe count in recipes.md intro (eight -> nine)

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,6 +1,6 @@
 # Recipes — copy-paste prompts that ship Hallmark output
 
-Eight worked briefs you can paste into Claude Code, Cursor, or Codex with the Hallmark skill installed. Each shows the prompt verbatim, the audience/use/tone the skill inferred, the macrostructure + theme + enrichment it picked, and a one-paragraph excerpt of the output. Live page links are included where the test exists in [`site/_tests/`](../../site/_tests/).
+Nine worked briefs you can paste into Claude Code, Cursor, or Codex with the Hallmark skill installed. Each shows the prompt verbatim, the audience/use/tone the skill inferred, the macrostructure + theme + enrichment it picked, and a one-paragraph excerpt of the output. Live page links are included where the test exists in [`site/_tests/`](../../site/_tests/).
 
 The first recipe is the **canonical try-it prompt** — paste it into a fresh project to verify the skill is installed and discover the flow before reading anything else.
 


### PR DESCRIPTION
The intro to `docs/recipes.md` says "Eight worked briefs", but the file documents nine recipes (00 Coffeebox through 08 Cohort), and the "What the recipes are not" section at the bottom already refers to "The 9 recipes here". This updates the intro sentence to say "Nine" so the two counts agree.
