### PR TITLE
audit: define genre handling when a page has no declaration

### DIFF
--- a/skills/hallmark/references/verbs/audit.md
+++ b/skills/hallmark/references/verbs/audit.md
@@ -15,6 +15,8 @@ Audit *also* checks structural fingerprint: if the page uses the AI template (ce
 
 **Genre-aware audit.** If the audited file's stamp names a genre (e.g. `genre: atmospheric`), apply the genre-scoped overrides from [`slop-test.md`](../slop-test.md) when grading. A radial-gradient background is a critical tell for editorial — but allowed for atmospheric. A pure-white paper is a tell for editorial — but allowed for modern-minimal. The audit verb must respect the genre the page declared.
 
+**No genre declaration.** If neither a CSS stamp nor `design.md` declares a genre, infer it from the page's visible product and design signals using the Design flow's genre-detection table. State `Inferred genre: <genre> (no declaration; <evidence>)` before the findings. If two non-default genres have comparable evidence, state `Genre ambiguous: <a> vs <b>` and apply only universal gates; do not escalate a genre-scoped gate until the page declares one.
+
 **`design.md` audit.** If the project root has a `design.md` (or `DESIGN.md`), read it before grading. Then check every audited page against the system:
 
 - **Theme drift.** Page uses tokens / fonts / accent that don't match `design.md`'s declared system → flag as `critical: design-system drift`. Per-page theme picks are slop on a system-managed project even if each page is internally fine.


### PR DESCRIPTION
## What happens

`audit.md` currently defines genre-aware grading only when the audited page already has a Hallmark stamp. Third-party pages usually have neither a Hallmark stamp nor `design.md`, so genre-scoped gates can change severity without the audit explaining which genre it applied.

I hit that boundary while auditing a real, unstamped homepage. The result was `0 critical · 1 major · 3 minor`, but the only major depended on treating the page as editorial. The same page also carried both AI-tool and developer-tool signals, which point to two non-default genres in the Design flow.

## The change

Adds one rule to the audit verb:

- infer an undeclared genre from visible product and design signals using the existing Design-flow table;
- state the inference and evidence before findings;
- when two non-default genres have comparable evidence, declare the ambiguity and apply only universal gates instead of escalating a genre-scoped rule.

This keeps the audit deterministic without forcing a third-party page to contain Hallmark metadata.

## Verification

- Current `main`: `aeb42fb`
- Docs/skill-instruction-only change; no runtime surface
- Existing stamp and `design.md` behavior is unchanged
- `git diff --check` passes
- No same-topic PR or issue found

The unstamped audit that exposed the gap is published with its other findings here: https://skillstested.com/compare/hallmark-vs-kill-ai-slop-vs-visual-skills/