### PR TITLE
fix(site): give the theme-picker dots real option roles

### DIFF
--- a/site/css/components.css
+++ b/site/css/components.css
@@ -542,7 +542,7 @@
   outline-offset: 2px;
 }
 
-.theme-dropdown__dot[aria-pressed="true"] {
+.theme-dropdown__dot[aria-selected="true"] {
   border-color: var(--color-ink);
   box-shadow: 0 0 0 2px var(--color-paper), 0 0 0 3px var(--color-ink);
 }

--- a/site/index.html
+++ b/site/index.html
@@ -133,67 +133,67 @@
       </button>
 
       <div class="theme-dropdown" id="theme-dropdown" role="listbox" aria-label="Theme picker" hidden>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="hum" aria-label="01 · Hum"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="hum" aria-label="01 · Hum"
           style="--dot: oklch(97% 0.012 95); --dot-edge: oklch(68% 0.24 18); --num: oklch(30% 0.05 18);"><span
             class="theme-dropdown__num">01</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="specimen" aria-label="02 · Specimen"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="specimen" aria-label="02 · Specimen"
           style="--dot: oklch(96% 0.018 80); --dot-edge: oklch(70% 0.04 75); --num: oklch(30% 0.05 75);"><span
             class="theme-dropdown__num">02</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="midnight" aria-label="03 · Midnight"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="midnight" aria-label="03 · Midnight"
           style="--dot: oklch(15% 0.022 250); --dot-edge: oklch(72% 0.16 220); --num: oklch(90% 0.04 220);"><span
             class="theme-dropdown__num">03</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="brutal" aria-label="04 · Brutal"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="brutal" aria-label="04 · Brutal"
           style="--dot: oklch(98% 0.001 0); --dot-edge: oklch(60% 0.21 27); --num: oklch(30% 0.05 27);"><span
             class="theme-dropdown__num">04</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="garden" aria-label="05 · Garden"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="garden" aria-label="05 · Garden"
           style="--dot: oklch(95.5% 0.022 92); --dot-edge: oklch(47% 0.13 140); --num: oklch(30% 0.05 140);"><span
             class="theme-dropdown__num">05</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="atelier" aria-label="06 · Atelier"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="atelier" aria-label="06 · Atelier"
           style="--dot: oklch(94% 0.005 60); --dot-edge: oklch(45% 0.13 60); --num: oklch(30% 0.05 60);"><span
             class="theme-dropdown__num">06</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="newsprint" aria-label="07 · Newsprint"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="newsprint" aria-label="07 · Newsprint"
           style="--dot: oklch(92% 0.045 50); --dot-edge: oklch(32% 0.10 28); --num: oklch(30% 0.05 28);"><span
             class="theme-dropdown__num">07</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="terminal" aria-label="08 · Terminal"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="terminal" aria-label="08 · Terminal"
           style="--dot: oklch(11% 0.018 145); --dot-edge: oklch(78% 0.19 138); --num: oklch(90% 0.05 138);"><span
             class="theme-dropdown__num">08</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="manifesto" aria-label="09 · Manifesto"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="manifesto" aria-label="09 · Manifesto"
           style="--dot: oklch(10% 0.005 60); --dot-edge: oklch(60% 0.22 27); --num: oklch(90% 0.04 27);"><span
             class="theme-dropdown__num">09</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="almanac" aria-label="10 · Almanac"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="almanac" aria-label="10 · Almanac"
           style="--dot: oklch(94% 0.008 245); --dot-edge: oklch(38% 0.135 250); --num: oklch(30% 0.05 250);"><span
             class="theme-dropdown__num">10</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="sport" aria-label="11 · Sport"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="sport" aria-label="11 · Sport"
           style="--dot: oklch(98% 0.003 250); --dot-edge: oklch(58% 0.190 35); --num: oklch(30% 0.05 35);"><span
             class="theme-dropdown__num">11</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="studio" aria-label="12 · Studio"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="studio" aria-label="12 · Studio"
           style="--dot: oklch(96.5% 0.014 95); --dot-edge: oklch(46% 0.140 145); --num: oklch(30% 0.05 145);"><span
             class="theme-dropdown__num">12</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="riso" aria-label="13 · Riso"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="riso" aria-label="13 · Riso"
           style="--dot: oklch(91% 0.034 30); --dot-edge: oklch(58% 0.170 220); --num: oklch(30% 0.05 220);"><span
             class="theme-dropdown__num">13</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="bloom" aria-label="14 · Bloom"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="bloom" aria-label="14 · Bloom"
           style="--dot: oklch(97% 0.010 72); --dot-edge: oklch(56% 0.13 35); --num: oklch(30% 0.05 35);"><span
             class="theme-dropdown__num">14</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="coral" aria-label="15 · Coral"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="coral" aria-label="15 · Coral"
           style="--dot: oklch(96.5% 0.005 50); --dot-edge: oklch(64% 0.165 28); --num: oklch(30% 0.05 28);"><span
             class="theme-dropdown__num">15</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="aurora" aria-label="16 · Aurora"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="aurora" aria-label="16 · Aurora"
           style="--dot: oklch(11% 0.025 200); --dot-edge: oklch(72% 0.170 200); --num: oklch(90% 0.05 200);"><span
             class="theme-dropdown__num">16</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="editorial" aria-label="17 · Editorial"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="editorial" aria-label="17 · Editorial"
           style="--dot: oklch(94% 0.020 75); --dot-edge: oklch(60% 0.160 35); --num: oklch(30% 0.05 35);"><span
             class="theme-dropdown__num">17</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="carnival" aria-label="18 · Carnival"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="carnival" aria-label="18 · Carnival"
           style="--dot: oklch(92% 0.075 85); --dot-edge: oklch(40% 0.13 25); --num: oklch(30% 0.05 25);"><span
             class="theme-dropdown__num">18</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="lumen" aria-label="19 · Lumen"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="lumen" aria-label="19 · Lumen"
           style="--dot: oklch(15% 0.016 265); --dot-edge: oklch(76% 0.13 60); --num: oklch(90% 0.05 60);"><span
             class="theme-dropdown__num">19</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="cobalt" aria-label="20 · Cobalt"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="cobalt" aria-label="20 · Cobalt"
           style="--dot: oklch(98.5% 0.004 250); --dot-edge: oklch(58% 0.20 256); --num: oklch(30% 0.05 256);"><span
             class="theme-dropdown__num">20</span></button>
-        <button class="theme-dropdown__dot" type="button" data-theme-btn="grid" aria-label="21 · Grid"
+        <button class="theme-dropdown__dot" type="button" role="option" aria-selected="false" data-theme-btn="grid" aria-label="21 · Grid"
           style="--dot: oklch(99% 0.003 255); --dot-edge: oklch(55% 0.21 28); --num: oklch(30% 0.06 28);"><span
             class="theme-dropdown__num">21</span></button>
       </div>

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -752,10 +752,10 @@ const ordinalEl   = document.querySelector("[data-theme-ordinal]");
 const themeKeys   = Object.keys(THEMES);
 const totalThemes = themeKeys.length;
 
-function setPressed(theme) {
+function setSelected(theme) {
   dots.forEach((btn) => {
     const active = btn.dataset.themeBtn === theme;
-    btn.setAttribute("aria-pressed", active ? "true" : "false");
+    btn.setAttribute("aria-selected", active ? "true" : "false");
   });
   const themeName = THEMES[theme] || "Specimen";
   const genre = THEME_GENRES[theme] || "editorial";
@@ -779,7 +779,7 @@ function applyTheme(theme) {
   const apply = () => {
     root.dataset.theme = theme;
     swapArchetypes(theme);
-    setPressed(theme);
+    setSelected(theme);
     try { localStorage.setItem(STORAGE_KEY, theme); } catch (e) { }
   };
   if (!reduced && document.startViewTransition) {
@@ -800,11 +800,11 @@ const initial = THEMES[queried] ? queried
     : (root.dataset.theme || "hum");
 
 // First paint — populate slots without a transition (no flash).
-// Run swapArchetypes BEFORE setPressed so the footer template is materialised
-// before setPressed writes the current-theme name into it.
+// Run swapArchetypes BEFORE setSelected so the footer template is materialised
+// before setSelected writes the current-theme name into it.
 root.dataset.theme = initial;
 swapArchetypes(initial);
-setPressed(initial);
+setSelected(initial);
 try { localStorage.setItem(STORAGE_KEY, initial); } catch (e) { }
 
 dots.forEach((btn) => {


### PR DESCRIPTION
## The problem

Screen readers announce the theme picker wrong. The trigger promises a listbox (`aria-haspopup="listbox"`) and the dropdown is `role="listbox"` — but its 21 dots are plain `<button>`s toggling `aria-pressed`. A listbox must own `role="option"` children carrying `aria-selected`; `aria-pressed` is not valid inside one. As shipped, assistive tech sees an empty listbox wrapping twenty-one unrelated toggle buttons, and the "current theme" state is invisible as a selection.

## The fix

- `site/index.html` — the 21 dots gain `role="option" aria-selected="false"` (buttons can legitimately take the option role).
- `site/js/main.js` — `setPressed` → `setSelected`; it now toggles `aria-selected` instead of `aria-pressed`. Same call sites, same behaviour otherwise.
- `site/css/components.css` — the active-dot ring keys off `[aria-selected="true"]` so the highlight doesn't silently break.

## Verified

Served `site/` locally and checked in Chrome: the dropdown exposes 21 `role="option"` children with exactly one `aria-selected="true"` matching the active theme; no `aria-pressed` remains on the landing page; the active dot still draws its ring (screenshot-checked); open/close and `aria-expanded` still behave; theme cycling still works — it runs through the same `applyTheme` → `setSelected` path exercised live. `node --check site/js/main.js` passes.

## Deliberately left alone

- Keyboard behaviour: the dots stay Tab-focusable. A full listbox pattern (roving tabindex + arrow keys + `aria-activedescendant`) is a larger change than this fix wants to be.
- The example pages (`site/examples/*`) keep their `aria-pressed` — those are genuine toggle buttons in `role="group"`, which is correct as-is.
- No overlap with #42 — that PR fixes the example-card link roles, not the picker.