### PR TITLE
perf(site): drop three unused families from the Google Fonts import

### DIFF
--- a/site/css/base.css
+++ b/site/css/base.css
@@ -1,7 +1,7 @@
 /* Hallmark — base: fonts, reset, body */
 
 /* — Google Fonts — all theme display & alt faces ——————————— */
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Instrument+Serif:ital@0;1&family=Cormorant+Garamond:ital,wght@0,300..700;1,300..700&family=Crimson+Pro:ital,wght@0,200..900;1,200..900&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&family=DM+Serif+Display:ital@0;1&family=Anton&family=Space+Grotesk:wght@300;400;500;600;700&family=Bricolage+Grotesque:opsz,wght@12..96,200..800&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..700&family=Hanken+Grotesk:ital,wght@0,100..900;1,100..900&family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400;1,500&family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Instrument+Serif:ital@0;1&family=Cormorant+Garamond:ital,wght@0,300..700;1,300..700&family=Crimson+Pro:ital,wght@0,200..900;1,200..900&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&family=Anton&family=Space+Grotesk:wght@300;400;500;600;700&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..700&family=Hanken+Grotesk:ital,wght@0,100..900;1,100..900&family=IBM+Plex+Mono:ital,wght@0,300;0,400;0,500;0,600;1,400&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap");
 
 /* — Reset ———————————————————————————————————————————— */
 *, *::before, *::after { box-sizing: border-box; }


### PR DESCRIPTION
## The problem

`site/css/base.css` opens with a render-blocking `@import` that fetches the theme faces from Google Fonts — but three of the fifteen families in that request are dead weight. **DM Serif Display**, **Bricolage Grotesque**, and **IBM Plex Sans** appear in zero `font-family` declarations across everything the landing page renders (`site/css/*`, `site/index.html` inline styles and SVGs, `site/js/main.js`). `base.css` is only linked by `site/index.html`, so nothing else inherits the import either. The example pages that do use Bricolage (wayfare, press-01, najm) load their own fonts through their own `<link>` tags and are unaffected.

## The fix

Remove the three families from the `@import` URL. One line.

## What it saves

Fetched both URLs with a Chrome UA:

- CSS response: 69,204 → 50,963 bytes uncompressed (−26%), 166 → 123 `@font-face` rules.
- Over the wire (gzip) the delta is modest — 2,960 → 2,394 bytes — repetitive `@font-face` CSS compresses well. The real win is less dead CSS to parse in the critical path and a smaller font-matching table.
- No change to which font files download: families that no rule references never got woff2 requests in the first place.

## Verified

- Searched every family name against `site/css/*.css`, `site/index.html` (including inline SVG `font-family` attributes) and `site/js/main.js`; the three removed families match nothing, and every family kept is referenced (Crimson Pro — Almanac body; Instrument Serif — Midnight/Aurora/Lumen serif; Plus Jakarta Sans — Hum; IBM Plex Mono — Salon mono, Terminal fallback…).
- Curled the exact trimmed URL from the edited file: valid response, 12 families, all the kept ones present.

## Deliberately left alone

- **Cormorant Garamond** stays: it is referenced as Atelier's display/serif fallback behind Playfair Display, so it isn't dead — just rarely reached.
- Seven families are loaded by both this `@import` and the `<link>` in `index.html` (with different axis ranges — e.g. upright Playfair 400..900 only exists here). Deduplicating those two requests is a real follow-up but needs per-theme weight auditing, so this PR doesn't touch it.
- The stale family list comment above the `<link>` in `index.html` — different file, different request; left for its own change if wanted.