### PR TITLE
fix(site): keep the theme label honest when T fires mid-hover

### DIFF
--- a/site/js/main.js
+++ b/site/js/main.js
@@ -1040,14 +1040,14 @@ dots.forEach((btn) => {
     lastConfirmed = root.dataset.theme;
     clearTimeout(previewTimer);
     previewTimer = setTimeout(() => {
+      // Theme changed mid-hover (T/R or a click) — keep the real name.
+      if (root.dataset.theme !== lastConfirmed) return;
       if (currentLabel) currentLabel.textContent = THEMES[btn.dataset.themeBtn];
     }, 80);
   });
   btn.addEventListener("mouseleave", () => {
     clearTimeout(previewTimer);
-    if (currentLabel && root.dataset.theme === lastConfirmed) {
-      currentLabel.textContent = THEMES[lastConfirmed];
-    }
+    if (currentLabel) currentLabel.textContent = THEMES[root.dataset.theme];
   });
 });
 


### PR DESCRIPTION
## The problem

Hover a theme dot and press <kbd>T</kbd> (or <kbd>R</kbd>) within the 80 ms preview window, and the banner label desyncs from the page: it can read "02 / 21 — Riso" while the page actually renders Specimen — and the wrong name *sticks* after the pointer leaves.

## The cause

`mouseenter` on a dot arms an 80 ms timer that writes the hovered theme's name into `.banner__theme` as a preview. If the theme swaps inside that window, the timer fires *after* `applyTheme` and overwrites the freshly-written name. The `mouseleave` restore then skips, because it only restored when the current theme still equalled the snapshot it took on enter — which is exactly false in this scenario. So the stale preview name sticks until the next theme change.

The swap lands inside the window synchronously whenever View Transitions are unavailable or `prefers-reduced-motion` is set (`applyTheme` runs `apply()` directly); with a view transition it is a race with the snapshot phase.

## The fix

Two lines in the hover-preview block:

- the preview timer bails if the theme changed since the hover began, and
- `mouseleave` restores the label from the live `root.dataset.theme` instead of the stale snapshot — the live theme is always the truth, so the restore no longer needs a guard.

## Verified

- Reproduced pre-fix in Chrome against the served site (reduced-motion emulation for the deterministic path): after `mouseenter` on the Riso dot + `T`, the state was `theme=specimen, label=Riso, ordinal=02 / 21`, and it survived `mouseleave`.
- Ran `index.html` + `main.js` in a jsdom harness (no `startViewTransition` there, so it exercises the same synchronous path) against both versions: upstream fails (`theme=specimen label=Riso` after the timer and after leave), fixed passes; the plain hover preview still shows the hovered name after 80 ms and restores the current name on leave.
- `node --check site/js/main.js` passes.

## Deliberately left alone

- The 80 ms delay and the preview behaviour itself — only the stale-write and the skipped restore are fixed.
- The unknown-`?theme=` fallback is #40's territory; this PR doesn't touch how `root.dataset.theme` gets validated.